### PR TITLE
Change order of kql statement execution

### DIFF
--- a/Solutions/Threat Intelligence/Analytic Rules/IPEntity_AzureKeyVault.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/IPEntity_AzureKeyVault.yaml
@@ -27,9 +27,10 @@ query: |
   let ioc_lookBack = 14d; // Look back 14 days for threat intelligence indicators
   // Fetch threat intelligence indicators related to IP addresses
   let IP_Indicators = ThreatIntelligenceIndicator
-    | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-    | where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
     | where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now()
+    | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+    | where Active == true
+    | where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
     | extend TI_ipEntity = iff(isnotempty(NetworkIP), NetworkIP, NetworkDestinationIP)
     | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(NetworkSourceIP), NetworkSourceIP, TI_ipEntity)
     | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(EmailSourceIpAddress), EmailSourceIpAddress, TI_ipEntity)


### PR DESCRIPTION
TimeGenerated was referenced after the data was summarised and therefore no longer visible.  Changed the order of statement execution to resovle the issue.