### PR TITLE
Remove entity mapping to SrcIpAddr

### DIFF
--- a/Solutions/Threat Intelligence/Analytic Rules/imDns_IPEntity_DnsEvents.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/imDns_IPEntity_DnsEvents.yaml
@@ -83,10 +83,6 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IoC
-  - entityType: IP
-    fieldMappings:
-      - identifier: Address
-        columnName: SrcIpAddr
   - entityType: DNS
     fieldMappings:
       - identifier: DomainName


### PR DESCRIPTION
Remove entity mapping of SrcIpAddr due to alert bombs that can result when errant entries are added to the TI.